### PR TITLE
Fix issue with cursor at the end of wrapped line

### DIFF
--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -127,7 +127,7 @@ function measureCursor(cm: any, view: EditorView, cursor: SelectionRange, primar
   var hCoeff = 1
 
   
-  let pos = view.coordsAtPos(head, cursor.assoc || 1)
+  let pos = view.coordsAtPos(head, 1)
   if (!pos) return null
   let base = getBase(view) 
   let letter = head < view.state.doc.length && view.state.sliceDoc(head, head + 1) 


### PR DESCRIPTION
# Why

This fixes the same flashing cursor problem described in [this comment in the Vim bindings repo](https://github.com/replit/codemirror-vim/issues/38#issuecomment-1201072187). The Emacs bindings have the same problem and the same fix to the block cursor.

# What changed

When a line wraps at a space, the cursor can no longer be placed after the space at the end of the first visual line.

# Test plan
To see the bug:

1. In `dev/index.html`, change the editor width to `30ch`
2. Run the dev server and navigate to it in a browser
3. On line 3 of the editor, place the cursor after the space that follows `from` at the end of the visual line
4. The cursor flashes and contains the next character, which is `'`. With this fix applied, the cursor cannot be placed in that location.